### PR TITLE
Use go templating on config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+singularity-config-generator


### PR DESCRIPTION
Remove the `replacePlaceholders` function and use go templating on the config file instead. This will enable use of go template language features like `{{ if eq .thing "banana" }}` etc in the singularity.yml files.

WARNING: This would be a breaking change, since all `singularity.yml` files which exist elsewhere would need updating to have `{{ .var_name }}` instead of `{{var}}`. @greyrhino can you advise on best way to go about that?

TODO:
- tests: This will be more involved than the current test, since we will have to test that the templating works correctly rather than just testing the string replacement function